### PR TITLE
Fix for memory leaks

### DIFF
--- a/aes/aes/local_support.c
+++ b/aes/aes/local_support.c
@@ -28,6 +28,7 @@ void input_to_data(int fd, void *vdata) {
   // Section 2: input-text
   s = find_section_start(p,2);
   parse_uint8_t_array(s, data->buf, 16);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -56,6 +57,7 @@ void output_to_data(int fd, void *vdata) {
   // Section 1: output-text
   s = find_section_start(p,1);
   parse_uint8_t_array(s, data->buf, 16);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/backprop/backprop/local_support.c
+++ b/backprop/backprop/local_support.c
@@ -51,6 +51,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,8);
   STAC(parse_,TYPE,_array)(s, data->training_targets, training_sets*possible_outputs);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -111,6 +112,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,6);
   STAC(parse_,TYPE,_array)(s, data->biases3, possible_outputs);
+  free(p);
 
 }
 

--- a/bfs/bulk/local_support.c
+++ b/bfs/bulk/local_support.c
@@ -48,6 +48,7 @@ void input_to_data(int fd, void *vdata) {
   // Section 3: edge structures
   s = find_section_start(p,3);
   parse_uint64_t_array(s, (uint64_t *)(data->edges), N_EDGES);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -87,6 +88,7 @@ void output_to_data(int fd, void *vdata) {
   // Section 1: horizon counts
   s = find_section_start(p,1);
   parse_uint64_t_array(s, data->level_counts, N_LEVELS);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/bfs/queue/local_support.c
+++ b/bfs/queue/local_support.c
@@ -48,6 +48,7 @@ void input_to_data(int fd, void *vdata) {
   // Section 3: edge structures
   s = find_section_start(p,3);
   parse_uint64_t_array(s, (uint64_t *)(data->edges), N_EDGES);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -87,6 +88,7 @@ void output_to_data(int fd, void *vdata) {
   // Section 1: horizon counts
   s = find_section_start(p,1);
   parse_uint64_t_array(s, data->level_counts, N_LEVELS);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/common/harness.c
+++ b/common/harness.c
@@ -68,6 +68,8 @@ int main(int argc, char **argv)
     return -1;
   }
   #endif
+  free(data);
+  free(ref);
 
   printf("Success.\n");
   return 0;

--- a/fft/strided/local_support.c
+++ b/fft/strided/local_support.c
@@ -38,6 +38,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,4);
   parse_double_array(s, data->img_twid, FFT_SIZE/2);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -76,6 +77,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   parse_double_array(s, data->img, FFT_SIZE);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/fft/transpose/local_support.c
+++ b/fft/transpose/local_support.c
@@ -28,6 +28,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   STAC(parse_,TYPE,_array)(s, data->work_y, 512);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -58,6 +59,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   STAC(parse_,TYPE,_array)(s, data->work_y, 512);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/gemm/blocked/local_support.c
+++ b/gemm/blocked/local_support.c
@@ -30,7 +30,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   STAC(parse_,TYPE,_array)(s, data->m2, N);
-
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -56,6 +56,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, data->prod, N);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/gemm/ncubed/local_support.c
+++ b/gemm/ncubed/local_support.c
@@ -30,6 +30,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   STAC(parse_,TYPE,_array)(s, data->m2, N);
+  free(p);
 
 }
 
@@ -56,6 +57,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, data->prod, N);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/kmp/kmp/local_support.c
+++ b/kmp/kmp/local_support.c
@@ -28,6 +28,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   parse_string(s, data->input, STRING_SIZE);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -55,6 +56,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   parse_int32_t_array(s, data->n_matches, 1);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/md/grid/local_support.c
+++ b/md/grid/local_support.c
@@ -30,6 +30,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   STAC(parse_,TYPE,_array)(s, (double *)(data->position), 3*blockSide*blockSide*blockSide*densityFactor);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -58,6 +59,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, (double *)data->force, 3*blockSide*blockSide*blockSide*densityFactor);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/md/knn/local_support.c
+++ b/md/knn/local_support.c
@@ -42,7 +42,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,4);
   parse_int32_t_array(s, data->NL, nAtoms*maxNeighbors);
-
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -87,7 +87,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,3);
   STAC(parse_,TYPE,_array)(s, data->force_z, nAtoms);
-
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/nw/nw/local_support.c
+++ b/nw/nw/local_support.c
@@ -28,6 +28,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   parse_string(s, data->seqB, BLEN);
+  free(p);
 
 }
 
@@ -63,6 +64,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   parse_string(s, data->alignedB, ALEN+BLEN);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/sort/merge/local_support.c
+++ b/sort/merge/local_support.c
@@ -23,6 +23,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, data->a, SIZE);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -47,6 +48,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, data->a, SIZE);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/sort/radix/local_support.c
+++ b/sort/radix/local_support.c
@@ -23,6 +23,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, data->a, SIZE);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -47,6 +48,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, data->a, SIZE);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/spmv/crs/local_support.c
+++ b/spmv/crs/local_support.c
@@ -40,6 +40,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,4);
   STAC(parse_,TYPE,_array)(s, data->vec, N);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -71,6 +72,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, data->out, N);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/spmv/ellpack/local_support.c
+++ b/spmv/ellpack/local_support.c
@@ -35,6 +35,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,3);
   STAC(parse_,TYPE,_array)(s, data->vec, N);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -63,6 +64,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, data->out, N);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/stencil/stencil2d/local_support.c
+++ b/stencil/stencil2d/local_support.c
@@ -30,6 +30,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   STAC(parse_,TYPE,_array)(s, data->filter, f_size);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -57,6 +58,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, data->sol, row_size*col_size);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/stencil/stencil3d/local_support.c
+++ b/stencil/stencil3d/local_support.c
@@ -28,6 +28,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,2);
   STAC(parse_,TYPE,_array)(s, data->orig, SIZE);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -53,6 +54,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   STAC(parse_,TYPE,_array)(s, data->sol, SIZE);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {

--- a/viterbi/viterbi/local_support.c
+++ b/viterbi/viterbi/local_support.c
@@ -38,6 +38,7 @@ void input_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,4);
   STAC(parse_,TYPE,_array)(s, data->emission, N_STATES*N_TOKENS);
+  free(p);
 }
 
 void data_to_input(int fd, void *vdata) {
@@ -71,6 +72,7 @@ void output_to_data(int fd, void *vdata) {
 
   s = find_section_start(p,1);
   parse_uint8_t_array(s, data->path, N_OBS);
+  free(p);
 }
 
 void data_to_output(int fd, void *vdata) {


### PR DESCRIPTION
I have noticed some memory leaks using valgrind.

Before fix

> **valgrind ./viterbi input.data check.data** 
> ![before](https://cloud.githubusercontent.com/assets/8297955/19022994/76f46aea-88ec-11e6-94b6-0e46fe765105.png)

After fix 

> **valgrind ./viterbi input.data check.data** 
> ![after](https://cloud.githubusercontent.com/assets/8297955/19022999/8f518c80-88ec-11e6-9110-7e1c42a6908e.png)
